### PR TITLE
fix(new_releases): Use marquee to avoid unintended resize of widgets

### DIFF
--- a/app/src/main/java/com/zionhuang/music/ui/component/Items.kt
+++ b/app/src/main/java/com/zionhuang/music/ui/component/Items.kt
@@ -6,7 +6,9 @@ import androidx.compose.animation.expandIn
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkOut
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -1191,6 +1193,7 @@ fun YouTubeListItem(
     isActive = isActive
 )
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun YouTubeGridItem(
     item: YTItem,
@@ -1376,13 +1379,14 @@ fun YouTubeGridItem(
         Spacer(modifier = Modifier.height(6.dp))
 
         Text(
+            modifier = Modifier
+                .basicMarquee().fillMaxWidth(),
             text = item.title,
             style = MaterialTheme.typography.bodyLarge,
             fontWeight = FontWeight.Bold,
-            maxLines = 2,
+            maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             textAlign = if (item is ArtistItem) TextAlign.Center else TextAlign.Start,
-            modifier = Modifier.fillMaxWidth()
         )
 
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -1397,10 +1401,12 @@ fun YouTubeGridItem(
 
             if (subtitle != null) {
                 Text(
+                    modifier = Modifier
+                        .basicMarquee(),
                     text = subtitle,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.secondary,
-                    maxLines = 2,
+                    maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
             }


### PR DESCRIPTION
This PR fixes the issue that occurs in case of a long album name or artist in new releases section while scrolling. I thought using a marquee would make it look better rather than normal text, which moves other widgets above and below while scrolling.