### PR TITLE
Pull translations of original InnerTune from Toolate Weblate instance

### DIFF
--- a/app/src/main/res/values-DE/strings.xml
+++ b/app/src/main/res/values-DE/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">Schnellauswahl</string>
     <string name="quick_picks_empty">Hören Sie sich einige Songs an, um Ihre Schnellauswahl zu treffen</string>
-    <string name="new_release_albums">Neu veröffentlichte Alben</string>
     <string name="forgotten_favorites">Vergessene Favoriten</string>
     <string name="similar_to">Ähnlich zu</string>
     <string name="keep_listening">Höre weiter</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -21,7 +21,6 @@
     <string name="account">Уліковы запіс</string>
     <string name="quick_picks">Хуткі выбар</string>
     <string name="quick_picks_empty">Праслухайце якія-небудзь кампазіцыі, каб стварыць ваш хуткі выбар.</string>
-    <string name="new_release_albums">Новыя рэлізы альбомаў</string>
 
     <!-- History -->
     <string name="today">Сёння</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">অ্যাকাউন্ট</string>
     <string name="quick_picks">দ্রুত পছন্দ</string>
     <string name="quick_picks_empty">আপনার নিজের শর্টকাট তৈরি করতে কিছু টিউন শুনুন</string>
-    <string name="new_release_albums">নতুন অ্যালবাম ও সিঙ্গেল</string>
 
     <!-- History -->
     <string name="today">আজ</string>

--- a/app/src/main/res/values-fa-rIR/strings.xml
+++ b/app/src/main/res/values-fa-rIR/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">حساب</string>
     <string name="quick_picks">انتخاب‌های سریع</string>
     <string name="quick_picks_empty">به ترانه‌ها گوش دهید تا انتخاب سریع خود ساخته شود</string>
-    <string name="new_release_albums">مجموعه‌های منتشرشده‌ی جدید</string>
 
     <!-- History -->
     <string name="today">امروز</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">Quick picks</string>
     <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">New release albums</string>
 
     <!-- History -->
     <string name="today">Today</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">Fiók</string>
     <string name="quick_picks">Gyors választás</string>
     <string name="quick_picks_empty">Hallgasson meg néhány dalt a gyors választások elkészítéséhez</string>
-    <string name="new_release_albums">Új kiadású albumok</string>
 
     <!-- History -->
     <string name="today">Ma</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -18,7 +18,6 @@
     <string name="account">Akun</string>
     <string name="quick_picks">Pilihan cepat</string>
     <string name="quick_picks_empty">Dengarkan lagu untuk menghasilkan pilihan cepat Anda</string>
-    <string name="new_release_albums">Album baru dirilis</string>
 
     <!-- History -->
     <string name="today">Hari ini</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -20,7 +20,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">Scelte rapide</string>
     <string name="quick_picks_empty">Ascolta alcuni brani per generare le tue scelte rapide</string>
-    <string name="new_release_albums">Nuovi album in uscita</string>
 
     <!-- History -->
     <string name="today">Oggi</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">アカウント</string>
     <string name="quick_picks">おすすめ</string>
     <string name="quick_picks_empty">何曲か再生するとおすすめを生成します</string>
-    <string name="new_release_albums">新作アルバム</string>
     <string name="forgotten_favorites">忘れられたお気に入り</string>
     <string name="similar_to">類似している:</string>
     <string name="keep_listening">聞き続ける</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -18,7 +18,6 @@
     <string name="account">계정</string>
     <string name="quick_picks">빠른 선곡</string>
     <string name="quick_picks_empty">빠른 선곡을 생성하려면 음악을 들으세요</string>
-    <string name="new_release_albums">새 앨범</string>
 
     <!-- History -->
     <string name="today">오늘</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">Quick picks</string>
     <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">New release albums</string>
 
     <!-- History -->
     <string name="today">Today</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">Snelle keuzes</string>
     <string name="quick_picks_empty">Beluister een aantal nummers om je snelle keuzes te genereren</string>
-    <string name="new_release_albums">Nieuwe albums</string>
 
     <!-- History -->
     <string name="today">Vandaag</string>

--- a/app/src/main/res/values-or-rIN/strings.xml
+++ b/app/src/main/res/values-or-rIN/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">Quick picks</string>
     <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">New release albums</string>
 
     <!-- History -->
     <string name="today">Today</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">ਉਂਗਲਾਂ ਤੇ ਚੁਣੇ ਗੀਤ</string>
     <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">ਨਵੀਆਂ ਜਾਰੀ ਐਲਬਮਾਂ</string>
 
     <!-- History -->
     <string name="today">ਅੱਜ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Bottom navigation -->
     <string name="home">Główna</string>
@@ -5,7 +6,6 @@
     <string name="artists">Wykonawcy</string>
     <string name="albums">Albumy</string>
     <string name="playlists">Playlisty</string>
-
     <!-- Top bar -->
     <plurals name="n_selected">
         <item quantity="one">%d zaznaczony</item>
@@ -13,7 +13,6 @@
         <item quantity="many">%d zaznaczonych</item>
         <item quantity="other">%d zaznaczonych</item>
     </plurals>
-
     <!-- Home -->
     <string name="history">Historia</string>
     <string name="stats">Statystyki</string>
@@ -22,18 +21,15 @@
     <string name="quick_picks">Szybki wybór</string>
     <string name="quick_picks_empty">Słuchaj utworów, aby wygenerować szybkie wybory</string>
     <string name="new_release_albums">Nowo wydane albumy</string>
-
     <!-- History -->
     <string name="today">Dzisiaj</string>
     <string name="yesterday">Wczoraj</string>
     <string name="this_week">Ten tydzień</string>
     <string name="last_week">Ostatni tydzień</string>
-
     <!-- Stats -->
     <string name="most_played_songs">Najczęściej słuchane utwory</string>
     <string name="most_played_artists">Najczęściej słuchani wykonawcy</string>
     <string name="most_played_albums">Najczęściej słuchane albumy</string>
-
     <!-- Search -->
     <string name="search">Szukaj</string>
     <string name="search_yt_music">Szukaj w YouTube Music…</string>
@@ -51,21 +47,17 @@
     <string name="filter_featured_playlists">Polecane playlisty</string>
     <string name="filter_bookmarked">Ulubione</string>
     <string name="no_results_found">Brak wyników</string>
-
     <!-- Artist screen -->
     <string name="from_your_library">Z twojej biblioteki</string>
-
     <!-- Playlist -->
     <string name="liked_songs">Polubione utwory</string>
     <string name="downloaded_songs">Pobrane utwory</string>
     <string name="playlist_is_empty">Playlista jest pusta</string>
-
     <!-- Button -->
     <string name="retry">Spróbuj ponownie</string>
     <string name="radio">Radio</string>
     <string name="shuffle">Losowo</string>
     <string name="reset">Reset</string>
-
     <!-- Menu -->
     <string name="details">Szczegóły</string>
     <string name="edit">Edytuj</string>
@@ -88,8 +80,7 @@
     <string name="remove_from_history">Usuń z historii</string>
     <string name="search_online">Szukaj online</string>
     <string name="sync">Synchronizuj</string>
-    <string name="advanced">Advanced</string>
-
+    <string name="advanced">Zaawansowany</string>
     <!-- Sort menu -->
     <string name="sort_by_create_date">Data dodania</string>
     <string name="sort_by_name">Nazwa</string>
@@ -99,7 +90,6 @@
     <string name="sort_by_length">Długość</string>
     <string name="sort_by_play_time">Długość utworu</string>
     <string name="sort_by_custom">Niestandardowa kolejność</string>
-
     <!-- Dialog -->
     <string name="media_id">ID media</string>
     <string name="mime_type">Typ MIME</string>
@@ -111,27 +101,22 @@
     <string name="file_size">Rozmiar pliku</string>
     <string name="unknown">Nieznane</string>
     <string name="copied">Skopiowano do schowka</string>
-
     <string name="edit_lyrics">Edytuj tekst</string>
     <string name="search_lyrics">Szukaj tekstu</string>
-
     <string name="edit_song">Edytuj utwór</string>
     <string name="song_title">Tytuł utworu</string>
     <string name="song_artists">Wykonawcy utworu</string>
     <string name="error_song_title_empty">Tytuł utworu nie może być pusty.</string>
     <string name="error_song_artist_empty">Wykonawca utworu nie może być pusty.</string>
     <string name="save">Zapisz</string>
-
     <string name="choose_playlist">Wybierz playlistę</string>
     <string name="edit_playlist">Edytuj playlistę</string>
     <string name="create_playlist">Utwórz playlistę</string>
     <string name="playlist_name">Nazwa playlisty</string>
     <string name="error_playlist_name_empty">Nazwa playlisty nie może być pusta.</string>
-
     <string name="edit_artist">Edytuj wykonawcę</string>
     <string name="artist_name">Nazwa wykonawcy</string>
     <string name="error_artist_name_empty">Nazwa wykonawcy nie może być pusta.</string>
-
     <!-- Noun -->
     <plurals name="n_song">
         <item quantity="one">%d utwór</item>
@@ -175,13 +160,11 @@
         <item quantity="many">%d lat</item>
         <item quantity="other">%d lat</item>
     </plurals>
-
     <!-- Snackbar -->
     <string name="playlist_imported">Playlista zaimportowana</string>
     <string name="removed_song_from_playlist">Usunięto \"%s\" z playlisty</string>
     <string name="playlist_synced">Playlista zsynchronizowana</string>
     <string name="undo">Cofnij</string>
-
     <!-- Player -->
     <string name="lyrics_not_found">Nie znaleziono tekstu</string>
     <string name="sleep_timer">Wyłącznik czasowy</string>
@@ -196,23 +179,19 @@
     <string name="error_no_internet">Brak połączenia z internetem</string>
     <string name="error_timeout">Upłynął limit czasu</string>
     <string name="error_unknown">Nieznany błąd</string>
-
     <!-- Player action -->
     <string name="action_like">Polub</string>
     <string name="action_remove_like">Usuń polubienie</string>
-    <string name="action_shuffle_on">Shuffle on</string>
-    <string name="action_shuffle_off">Shuffle off</string>
-    <string name="repeat_mode_off">Repeat mode off</string>
-    <string name="repeat_mode_one">Repeat current song</string>
-    <string name="repeat_mode_all">Repeat queue</string>
-
+    <string name="action_shuffle_on">Tasowanie włączone</string>
+    <string name="action_shuffle_off">Tasowanie wyłączone</string>
+    <string name="repeat_mode_off">Tryb powtarzania wyłączony</string>
+    <string name="repeat_mode_one">Powtórz bieżący utwór</string>
+    <string name="repeat_mode_all">Powtórz kolejkę</string>
     <!-- Queue Title -->
     <string name="queue_all_songs">Wszystkie utwory</string>
     <string name="queue_searched_songs">Wyszukane utwory</string>
-
     <!-- Notification name -->
     <string name="music_player">Odtwarzacz</string>
-
     <!-- Settings -->
     <string name="settings">Ustawienia</string>
     <string name="appearance">Wygląd</string>
@@ -228,7 +207,6 @@
     <string name="left">Z lewej</string>
     <string name="center">Na środku</string>
     <string name="right">Z prawej</string>
-
     <string name="content">Zawartość</string>
     <string name="login">Zaloguj się</string>
     <string name="content_language">Domyślny język zawartości</string>
@@ -238,7 +216,6 @@
     <string name="proxy_type">Typ proxy</string>
     <string name="proxy_url">URL proxy</string>
     <string name="restart_to_take_effect">Uruchom ponownie, aby zastosować zmiany</string>
-
     <string name="player_and_audio">Odtwarzacz i audio</string>
     <string name="audio_quality">Jakość audio</string>
     <string name="audio_quality_auto">Automatyczna</string>
@@ -248,7 +225,6 @@
     <string name="skip_silence">Pomiń ciszę</string>
     <string name="audio_normalization">Normalizacja audio</string>
     <string name="equalizer">Korektor graficzny</string>
-
     <string name="storage">Pamięć</string>
     <string name="cache">Cache</string>
     <string name="image_cache">Cache obrazów</string>
@@ -261,7 +237,6 @@
     <string name="max_song_cache_size">Maksymalny rozmiar cache utworów</string>
     <string name="clear_song_cache">Wyczyść cache utworów</string>
     <string name="size_used">%s w użyciu</string>
-
     <string name="privacy">Prywatność</string>
     <string name="pause_listen_history">Wstrzymaj historię odtwarzania</string>
     <string name="clear_listen_history">Wyczyść historię odtwarzania</string>
@@ -270,7 +245,6 @@
     <string name="clear_search_history">Wyczyść historię wyszukiwania</string>
     <string name="clear_search_history_confirm">Czy na pewno chcesz wyczyścić całą historię wyszukiwania?</string>
     <string name="enable_kugou">Pobieraj teksty utworów z KuGou</string>
-
     <string name="backup_restore">Kopia zapasowa i przywracanie</string>
     <string name="backup">Utwórz kopię zapasową</string>
     <string name="restore">Przywróć</string>
@@ -278,11 +252,9 @@
     <string name="backup_create_success">Kopia zapasowa utworzona pomyślnie</string>
     <string name="backup_create_failed">Nie udało się stworzyć kopii zapasowej</string>
     <string name="restore_failed">Nie udało się przywrócić kopii zapasowej</string>
-
     <string name="about">O aplikacji</string>
     <string name="app_version">Wersja aplikacji</string>
-
     <string name="new_version_available">Dostępna nowa wersja</string>
-    <string name="translation_models">Translation Models</string>
-    <string name="clear_translation_models">Clear translation models</string>
+    <string name="translation_models">Modele Tłumaczenia</string>
+    <string name="clear_translation_models">Wyczyść modele tłumaczenia</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Bottom navigation -->
     <string name="home">Início</string>
@@ -5,41 +6,36 @@
     <string name="artists">Artistas</string>
     <string name="albums">Álbuns</string>
     <string name="playlists">Playlists</string>
-
     <!-- Top bar -->
     <plurals name="n_selected">
         <item quantity="one">%d selecionada</item>
         <item quantity="other">%d selecionadas</item>
         <item quantity="many">%d selecionadas</item>
     </plurals>
-
     <!-- Home -->
-    <string name="history">History</string>
-    <string name="stats">Stats</string>
-    <string name="mood_and_genres">Mood and Genres</string>
-    <string name="account">Account</string>
-    <string name="quick_picks">Quick picks</string>
-    <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">New release álbuns</string>
-
+    <string name="history">Histórico</string>
+    <string name="stats">Estatísticas</string>
+    <string name="mood_and_genres">Humor e Gêneros</string>
+    <string name="account">Conta</string>
+    <string name="quick_picks">Escolhas rápidas</string>
+    <string name="quick_picks_empty">Escute mais para gerar suas escolhas rápidas</string>
+    <string name="new_release_albums">Novos lançamentos de álbuns</string>
     <!-- History -->
-    <string name="today">Today</string>
-    <string name="yesterday">Yesterday</string>
-    <string name="this_week">This week</string>
-    <string name="last_week">Last week</string>
-
+    <string name="today">Hoje</string>
+    <string name="yesterday">Ontem</string>
+    <string name="this_week">Essa semana</string>
+    <string name="last_week">Semana passada</string>
     <!-- Stats -->
-    <string name="most_played_songs">Most played songs</string>
-    <string name="most_played_artists">Most played artists</string>
-    <string name="most_played_albums">Most played álbuns</string>
-
+    <string name="most_played_songs">Músicas mais tocadas</string>
+    <string name="most_played_artists">Artistas mais tocados</string>
+    <string name="most_played_albums">Álbuns mais tocados</string>
     <!-- Search -->
     <string name="search">Pesquisar</string>
     <string name="search_yt_music">Pesquisar no YouTube Music…</string>
     <string name="search_library">Pesquisar na biblioteca…</string>
-    <string name="filter_library">Library</string>
-    <string name="filter_liked">Liked</string>
-    <string name="filter_downloaded">Downloaded</string>
+    <string name="filter_library">Biblioteca</string>
+    <string name="filter_liked">Curtidas</string>
+    <string name="filter_downloaded">Baixados</string>
     <string name="filter_all">Tudo</string>
     <string name="filter_songs">Músicas</string>
     <string name="filter_videos">Vídeos</string>
@@ -48,35 +44,31 @@
     <string name="filter_playlists">Playlists</string>
     <string name="filter_community_playlists">Playlists da comunidade</string>
     <string name="filter_featured_playlists">Playlists em destaque</string>
-    <string name="filter_bookmarked">Bookmarked</string>
-    <string name="no_results_found">No results found</string>
-
+    <string name="filter_bookmarked">Favoritadas</string>
+    <string name="no_results_found">Nenhum resultado encontrado</string>
     <!-- Artist screen -->
     <string name="from_your_library">Da sua biblioteca</string>
-
     <!-- Playlist -->
     <string name="liked_songs">Músicas favoritas</string>
     <string name="downloaded_songs">Músicas baixadas</string>
-    <string name="playlist_is_empty">The playlist is empty</string>
-
+    <string name="playlist_is_empty">Esta playlist está vazia</string>
     <!-- Button -->
     <string name="retry">Tentar novamente</string>
     <string name="radio">Rádio</string>
     <string name="shuffle">Aleatório</string>
-    <string name="reset">Reset</string>
-
+    <string name="reset">Redefinir</string>
     <!-- Menu -->
     <string name="details">Detalhes</string>
     <string name="edit">Editar</string>
     <string name="start_radio">Iniciar rádio</string>
-    <string name="play">Tocar</string>
-    <string name="play_next">Tocar em seguida</string>
+    <string name="play">Reproduzir</string>
+    <string name="play_next">Reproduzir em seguida</string>
     <string name="add_to_queue">Adicionar à fila</string>
     <string name="add_to_library">Adicionar à biblioteca</string>
     <string name="remove_from_library">Remover da biblioteca</string>
-    <string name="download">Download</string>
-    <string name="downloading">Downloading</string>
-    <string name="remove_download">Remover download</string>
+    <string name="download">Baixar</string>
+    <string name="downloading">Baixando</string>
+    <string name="remove_download">Remover das músicas baixadas</string>
     <string name="import_playlist">Importar playlist</string>
     <string name="add_to_playlist">Adicionar à playlist</string>
     <string name="view_artist">Ver artista</string>
@@ -84,53 +76,46 @@
     <string name="refetch">Atualizar</string>
     <string name="share">Compartilhar</string>
     <string name="delete">Excluir</string>
-    <string name="remove_from_history">Remove from history</string>
-    <string name="search_online">Search online</string>
-    <string name="sync">Sync</string>
-    <string name="advanced">Advanced</string>
-
+    <string name="remove_from_history">Remover do histórico</string>
+    <string name="search_online">Buscar online</string>
+    <string name="sync">Sincronização</string>
+    <string name="advanced">Avançado</string>
     <!-- Sort menu -->
-    <string name="sort_by_create_date">Quando adicionada</string>
+    <string name="sort_by_create_date">Data adicionada</string>
     <string name="sort_by_name">Nome</string>
     <string name="sort_by_artist">Artista</string>
     <string name="sort_by_year">Ano</string>
-    <string name="sort_by_song_count">Número da faixa</string>
-    <string name="sort_by_length">Tamanho</string>
+    <string name="sort_by_song_count">Quantidade de músicas</string>
+    <string name="sort_by_length">Duração</string>
     <string name="sort_by_play_time">Tempo de reprodução</string>
-    <string name="sort_by_custom">Custom order</string>
-
+    <string name="sort_by_custom">Ordem customizada</string>
     <!-- Dialog -->
-    <string name="media_id">Media id</string>
-    <string name="mime_type">MIME type</string>
-    <string name="codecs">Codecs</string>
-    <string name="bitrate">Bitrate</string>
-    <string name="sample_rate">Sample rate</string>
-    <string name="loudness">Loudness</string>
+    <string name="media_id">ID de mídia</string>
+    <string name="mime_type">Tipo do MIME</string>
+    <string name="codecs">Codificações</string>
+    <string name="bitrate">Taxa de bits</string>
+    <string name="sample_rate">Taxa de amostragem</string>
+    <string name="loudness">Volume</string>
     <string name="volume">Volume</string>
     <string name="file_size">Tamanho do arquivo</string>
     <string name="unknown">Desconhecido</string>
-    <string name="copied">Copiado para à área de transferência</string>
-
-    <string name="edit_lyrics">Edit lyrics</string>
-    <string name="search_lyrics">Search lyrics</string>
-
+    <string name="copied">Copiado para a área de transferência</string>
+    <string name="edit_lyrics">Editar letras</string>
+    <string name="search_lyrics">Buscar letras</string>
     <string name="edit_song">Editar música</string>
-    <string name="song_title">Título da Música</string>
-    <string name="song_artists">Artista da Música</string>
-    <string name="error_song_title_empty">O título da música não pode ficar vazio.</string>
-    <string name="error_song_artist_empty">O artista da música não pode ficar vazio.</string>
+    <string name="song_title">Título da música</string>
+    <string name="song_artists">Artistas da música</string>
+    <string name="error_song_title_empty">O título da música não pode ser vazio.</string>
+    <string name="error_song_artist_empty">O artista da música não pode ser vazio.</string>
     <string name="save">Salvar</string>
-
     <string name="choose_playlist">Escolher playlist</string>
     <string name="edit_playlist">Editar playlist</string>
     <string name="create_playlist">Criar playlist</string>
     <string name="playlist_name">Nome da playlist</string>
-    <string name="error_playlist_name_empty">O nome da playlist não pode ficar vazio.</string>
-
+    <string name="error_playlist_name_empty">O nome da playlist não pode ser vazio.</string>
     <string name="edit_artist">Editar artista</string>
     <string name="artist_name">Nome do artista</string>
-    <string name="error_artist_name_empty">O nome do artista não pode ficar vazio.</string>
-
+    <string name="error_artist_name_empty">O nome do artista não pode ser vazio.</string>
     <!-- Noun -->
     <plurals name="n_song">
         <item quantity="one">%d música</item>
@@ -153,73 +138,66 @@
         <item quantity="many">%d playlists</item>
     </plurals>
     <plurals name="n_week">
-        <item quantity="one">%d week</item>
-        <item quantity="other">%d weeks</item>
-        <item quantity="many">%d weeks</item>
+        <item quantity="one">%d semana</item>
+        <item quantity="many">%d semanas</item>
+        <item quantity="other">%d semanas</item>
     </plurals>
     <plurals name="n_month">
-        <item quantity="one">%d month</item>
-        <item quantity="other">%d months</item>
-        <item quantity="many">%d months</item>
+        <item quantity="one">%d mês</item>
+        <item quantity="many">%d meses</item>
+        <item quantity="other">%d meses</item>
     </plurals>
     <plurals name="n_year">
-        <item quantity="one">%d year</item>
-        <item quantity="other">%d years</item>
-        <item quantity="many">%d years</item>
+        <item quantity="one">%d ano</item>
+        <item quantity="many">%d anos</item>
+        <item quantity="other">%d anos</item>
     </plurals>
-
     <!-- Snackbar -->
     <string name="playlist_imported">Playlist importada</string>
-    <string name="removed_song_from_playlist">Removed \"%s\" from playlist</string>
-    <string name="playlist_synced">Playlist synced</string>
-    <string name="undo">Undo</string>
-
+    <string name="removed_song_from_playlist">\"%s\" removido da playlist</string>
+    <string name="playlist_synced">Playlist sincronizada</string>
+    <string name="undo">Desfazer</string>
     <!-- Player -->
-    <string name="lyrics_not_found">Lyrics not found</string>
-    <string name="sleep_timer">Sleep timer</string>
-    <string name="end_of_song">End of song</string>
+    <string name="lyrics_not_found">Letras não encontradas</string>
+    <string name="sleep_timer">Timer para dormir</string>
+    <string name="end_of_song">Fim da música</string>
     <plurals name="minute">
-        <item quantity="one">%d minute</item>
-        <item quantity="other">%d minutes</item>
-        <item quantity="many">%d minutes</item>
+        <item quantity="one">%d minuto</item>
+        <item quantity="many">%d minutos</item>
+        <item quantity="other">%d minutos</item>
     </plurals>
     <string name="error_no_stream">Nenhum canal de reprodução disponível</string>
     <string name="error_no_internet">Sem conexão com à internet</string>
     <string name="error_timeout">Tempo esgotado</string>
     <string name="error_unknown">Erro desconhecido</string>
-
     <!-- Player action -->
     <string name="action_like">Favoritar</string>
     <string name="action_remove_like">Remover dos favoritos</string>
-    <string name="action_shuffle_on">Shuffle on</string>
-    <string name="action_shuffle_off">Shuffle off</string>
-    <string name="repeat_mode_off">Repeat mode off</string>
-    <string name="repeat_mode_one">Repeat current song</string>
-    <string name="repeat_mode_all">Repeat queue</string>
-
+    <string name="action_shuffle_on">Modo aleatório ativado</string>
+    <string name="action_shuffle_off">Modo aleatório desativado</string>
+    <string name="repeat_mode_off">Repetição desativada</string>
+    <string name="repeat_mode_one">Repetir a música atual</string>
+    <string name="repeat_mode_all">Repetir fila</string>
     <!-- Queue Title -->
     <string name="queue_all_songs">Todas as músicas</string>
     <string name="queue_searched_songs">Músicas pesquisadas</string>
-
     <!-- Notification name -->
     <string name="music_player">Reprodutor de Música</string>
-
     <!-- Settings -->
     <string name="settings">Configurações</string>
     <string name="appearance">Aparência</string>
-    <string name="enable_dynamic_theme">Enable dynamic theme</string>
+    <string name="enable_dynamic_theme">Ativar tema dinâmico</string>
     <string name="dark_theme">Tema escuro</string>
     <string name="dark_theme_on">On</string>
-    <string name="dark_theme_off">Off</string>
+    <string name="dark_theme_off">Desativado</string>
     <string name="dark_theme_follow_system">Seguir o sistema</string>
-    <string name="pure_black">Pure black</string>
-    <string name="default_open_tab">Aba padrão ao iniciar</string>
-    <string name="customize_navigation_tabs">Costumar barra de navegação</string>
-    <string name="lyrics_text_position">Lyrics text position</string>
-    <string name="left">Left</string>
-    <string name="center">Center</string>
-    <string name="right">Right</string>
-
+    <string name="pure_black">Preto puro</string>
+    <string name="default_open_tab">Aba padrão ao abrir o app</string>
+    <string name="customize_navigation_tabs">Customizar abas de navegação</string>
+    <string name="lyrics_text_position">Posição do texto das letras</string>
+    <string name="left">Esquerda</string>
+    <string name="center">Centro</string>
+    <string name="right">Direita</string>
     <string name="content">Conteúdo</string>
     <string name="login">Login</string>
     <string name="content_language">Idioma padrão do conteúdo</string>
@@ -227,53 +205,49 @@
     <string name="system_default">Padrão do sistema</string>
     <string name="enable_proxy">Ativar proxy</string>
     <string name="proxy_type">Tipo de proxy</string>
-    <string name="proxy_url">URL do proxy</string>
-    <string name="restart_to_take_effect">Reiniciar para ativar proxy</string>
-
-    <string name="player_and_audio">Player e áudio</string>
+    <string name="proxy_url">URL da proxy</string>
+    <string name="restart_to_take_effect">Reinicie para fazer efeito</string>
+    <string name="player_and_audio">Reprodutor e áudio</string>
     <string name="audio_quality">Qualidade do áudio</string>
     <string name="audio_quality_auto">Automática</string>
     <string name="audio_quality_high">Alta</string>
     <string name="audio_quality_low">Baixa</string>
     <string name="persistent_queue">Fila persistente</string>
-    <string name="skip_silence">Skip silence</string>
-    <string name="audio_normalization">Audio normalization</string>
+    <string name="skip_silence">Pular silêncio</string>
+    <string name="audio_normalization">Normalização de áudio</string>
     <string name="equalizer">Equalizador</string>
-
-    <string name="storage">Storage</string>
+    <string name="storage">Armazenamento</string>
     <string name="cache">Cache</string>
-    <string name="image_cache">Image Cache</string>
-    <string name="song_cache">Song Cache</string>
-    <string name="max_cache_size">Max cache size</string>
-    <string name="unlimited">Unlimited</string>
-    <string name="clear_all_downloads">Clear all downloads</string>
-    <string name="max_image_cache_size">Tamanho máximo do chace de imagens</string>
+    <string name="image_cache">Cache de Imagens</string>
+    <string name="song_cache">Cache de Músicas</string>
+    <string name="max_cache_size">Tamanho máximo da cache</string>
+    <string name="unlimited">Ilimitado</string>
+    <string name="clear_all_downloads">Limpar todos os downloads</string>
+    <string name="max_image_cache_size">Tamanho máximo do cache de imagens</string>
     <string name="clear_image_cache">Limpar cache de imagens</string>
     <string name="max_song_cache_size">Tamanho máximo do cache de músicas</string>
-    <string name="clear_song_cache">Clear song cache</string>
+    <string name="clear_song_cache">Limpar a cache de músicas</string>
     <string name="size_used">%s usados</string>
-
     <string name="privacy">Privacidade</string>
-    <string name="pause_listen_history">Pause listen history</string>
-    <string name="clear_listen_history">Clear listen history</string>
-    <string name="clear_listen_history_confirm">Are you sure to clear all listen history?</string>
+    <string name="pause_listen_history">Pausar o histórico</string>
+    <string name="clear_listen_history">Limpar o histórico</string>
+    <string name="clear_listen_history_confirm">Você tem certeza que deseja limpar todo o histórico?</string>
     <string name="pause_search_history">Pausar histórico de pesquisa</string>
     <string name="clear_search_history">Limpar histórico de pesquisa</string>
-    <string name="clear_search_history_confirm">Tem certeza que deseja deletar todo o seu histórico de pesquisa?</string>
-    <string name="enable_kugou">Enable KuGou lyrics provider</string>
-
+    <string name="clear_search_history_confirm">Tem certeza que deseja limpar todo o seu histórico de pesquisa?</string>
+    <string name="enable_kugou">Ativar o provedor de letras \"KuGou\"</string>
     <string name="backup_restore">Backup e restauração</string>
-    <string name="backup">Backup</string>
+    <string name="backup">Fazer backup</string>
     <string name="restore">Restaurar</string>
-    <string name="imported_playlist">Imported playlist</string>
+    <string name="imported_playlist">Playlist importada</string>
     <string name="backup_create_success">Backup criado com sucesso</string>
     <string name="backup_create_failed">Não foi possível criar o backup</string>
     <string name="restore_failed">Falha ao restaurar o backup</string>
-
     <string name="about">Sobre</string>
-    <string name="app_version">Versão do aplicativo</string>
-
-    <string name="new_version_available">New version available</string>
-    <string name="translation_models">Translation Models</string>
-    <string name="clear_translation_models">Clear translation models</string>
+    <string name="app_version">Versão do app</string>
+    <string name="new_version_available">Nova versão disponível</string>
+    <string name="translation_models">Modelos de Tradução</string>
+    <string name="clear_translation_models">Limpar modelos de tradução</string>
+    <string name="remove_download_playlist_confirm">Você deseja realmente remover as músicas da playlist \"%s\" do armazenamento de Músicas Baixadas?</string>
+    <string name="delete_playlist_confirm">Você deseja realmente excluir a playlist \"%s\"?</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -20,7 +20,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">Quick picks</string>
     <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">New release álbuns</string>
 
     <!-- History -->
     <string name="today">Today</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -188,7 +188,7 @@
     <string name="appearance">Aparência</string>
     <string name="enable_dynamic_theme">Ativar tema dinâmico</string>
     <string name="dark_theme">Tema escuro</string>
-    <string name="dark_theme_on">On</string>
+    <string name="dark_theme_on">Ativado</string>
     <string name="dark_theme_off">Desativado</string>
     <string name="dark_theme_follow_system">Seguir o sistema</string>
     <string name="pure_black">Preto puro</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -21,7 +21,6 @@
     <string name="account">Аккаунт</string>
     <string name="quick_picks">Быстрый выбор</string>
     <string name="quick_picks_empty">Послушайте несколько песен, чтобы создать ваш быстрый выбор</string>
-    <string name="new_release_albums">Новые релизы альбомов</string>
     <string name="forgotten_favorites">Забытые любимые песни</string>
     <string name="similar_to">Похожие на</string>
     <string name="keep_listening">Продолжайте слушать</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">Quick picks</string>
     <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">New release albums</string>
 
     <!-- History -->
     <string name="today">Today</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -21,7 +21,6 @@
     <string name="account">Акаунт</string>
     <string name="quick_picks">Швидкий вибір</string>
     <string name="quick_picks_empty">Послухайте кілька пісень, щоб створити ваш швидкий вибір</string>
-    <string name="new_release_albums">Нові релізи альбомів</string>
 
     <!-- History -->
     <string name="today">Сьогодні</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -18,7 +18,6 @@
     <string name="account">Tài Khoản</string>
     <string name="quick_picks">Chọn nhanh</string>
     <string name="quick_picks_empty">Nghe các bài hát để tạo danh sách chọn nhanh của bạn</string>
-    <string name="new_release_albums">Các albums mới phát hành</string>
 
     <!-- History -->
     <string name="today">Hôm nay</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -18,7 +18,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">歌曲快选</string>
     <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">新专辑</string>
 
     <!-- History -->
     <string name="today">今天</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -16,7 +16,7 @@
     <string name="mood_and_genres">情绪和流派</string>
     <string name="account">Account</string>
     <string name="quick_picks">歌曲快选</string>
-    <string name="quick_picks_empty">听一些歌曲来快速挑选</string>
+    <string name="quick_picks_empty">听一些歌曲来生成歌曲快选</string>
     <string name="new_release_albums">新专辑</string>
     <!-- History -->
     <string name="today">今天</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Bottom navigation -->
     <string name="home">首页</string>
@@ -5,39 +6,34 @@
     <string name="artists">音乐人</string>
     <string name="albums">专辑</string>
     <string name="playlists">播放列表</string>
-
     <!-- Top bar -->
     <plurals name="n_selected">
         <item quantity="other">已选择 %d 个项目</item>
     </plurals>
-
     <!-- Home -->
     <string name="history">历史记录</string>
     <string name="stats">统计</string>
-    <string name="mood_and_genres">Mood and Genres</string>
+    <string name="mood_and_genres">情绪和流派</string>
     <string name="account">Account</string>
     <string name="quick_picks">歌曲快选</string>
-    <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
+    <string name="quick_picks_empty">听一些歌曲来快速挑选</string>
     <string name="new_release_albums">新专辑</string>
-
     <!-- History -->
     <string name="today">今天</string>
     <string name="yesterday">昨天</string>
     <string name="this_week">这周</string>
     <string name="last_week">上周</string>
-
     <!-- Stats -->
     <string name="most_played_songs">最常播放</string>
-    <string name="most_played_artists">Most played artists</string>
-    <string name="most_played_albums">Most played albums</string>
-
+    <string name="most_played_artists">最受欢迎的音乐人</string>
+    <string name="most_played_albums">播放次数最多的专辑</string>
     <!-- Search -->
     <string name="search">搜索</string>
     <string name="search_yt_music">搜索 YouTube Music…</string>
     <string name="search_library">搜索媒体库…</string>
-    <string name="filter_library">Library</string>
-    <string name="filter_liked">Liked</string>
-    <string name="filter_downloaded">Downloaded</string>
+    <string name="filter_library">库</string>
+    <string name="filter_liked">喜欢</string>
+    <string name="filter_downloaded">已下载</string>
     <string name="filter_all">全部</string>
     <string name="filter_songs">歌曲</string>
     <string name="filter_videos">视频</string>
@@ -46,23 +42,19 @@
     <string name="filter_playlists">播放列表</string>
     <string name="filter_community_playlists">社区播放列表</string>
     <string name="filter_featured_playlists">精选播放列表</string>
-    <string name="filter_bookmarked">Bookmarked</string>
+    <string name="filter_bookmarked">已加书签</string>
     <string name="no_results_found">找不到结果</string>
-
     <!-- Artist screen -->
     <string name="from_your_library">来自您的媒体库</string>
-
     <!-- Playlist -->
     <string name="liked_songs">喜欢的歌曲</string>
     <string name="downloaded_songs">已下载的歌曲</string>
     <string name="playlist_is_empty">播放列表为空</string>
-
     <!-- Button -->
     <string name="retry">重试</string>
     <string name="radio">电台</string>
     <string name="shuffle">随机播放</string>
     <string name="reset">Reset</string>
-
     <!-- Menu -->
     <string name="details">详情</string>
     <string name="edit">编辑</string>
@@ -73,7 +65,7 @@
     <string name="add_to_library">加入媒体库</string>
     <string name="remove_from_library">从媒体库中移除</string>
     <string name="download">下载</string>
-    <string name="downloading">Downloading</string>
+    <string name="downloading">正在下载</string>
     <string name="remove_download">删除下载</string>
     <string name="import_playlist">导入播放列表</string>
     <string name="add_to_playlist">加入播放列表</string>
@@ -85,8 +77,7 @@
     <string name="remove_from_history">从记录中移除</string>
     <string name="search_online">在线搜索</string>
     <string name="sync">同步</string>
-    <string name="advanced">Advanced</string>
-
+    <string name="advanced">高级</string>
     <!-- Sort menu -->
     <string name="sort_by_create_date">新建时间</string>
     <string name="sort_by_name">名称</string>
@@ -95,8 +86,7 @@
     <string name="sort_by_song_count">歌曲总数</string>
     <string name="sort_by_length">长度</string>
     <string name="sort_by_play_time">播放时间</string>
-    <string name="sort_by_custom">Custom order</string>
-
+    <string name="sort_by_custom">自定义顺序</string>
     <!-- Dialog -->
     <string name="media_id">媒体 ID</string>
     <string name="mime_type">MIME 类型</string>
@@ -108,27 +98,22 @@
     <string name="file_size">文件大小</string>
     <string name="unknown">未知</string>
     <string name="copied">已复制到剪贴板</string>
-
     <string name="edit_lyrics">编辑歌词</string>
     <string name="search_lyrics">搜索歌词</string>
-
     <string name="edit_song">编辑歌曲</string>
     <string name="song_title">歌名</string>
     <string name="song_artists">音乐人</string>
-    <string name="error_song_title_empty">歌名不能为空</string>
-    <string name="error_song_artist_empty">音乐人不能为空</string>
+    <string name="error_song_title_empty">歌名不能为空。</string>
+    <string name="error_song_artist_empty">音乐人不能为空。</string>
     <string name="save">保存</string>
-
     <string name="choose_playlist">选择播放列表</string>
     <string name="edit_playlist">编辑播放列表</string>
     <string name="create_playlist">新建播放列表</string>
     <string name="playlist_name">名称</string>
-    <string name="error_playlist_name_empty">播放列表名称不能为空</string>
-
+    <string name="error_playlist_name_empty">播放列表名称不能为空。</string>
     <string name="edit_artist">编辑音乐人</string>
     <string name="artist_name">音乐人名称</string>
-    <string name="error_artist_name_empty">音乐人名称不能为空</string>
-
+    <string name="error_artist_name_empty">音乐人名称不能为空。</string>
     <!-- Noun -->
     <plurals name="n_song">
         <item quantity="other">%d 首歌曲</item>
@@ -143,21 +128,19 @@
         <item quantity="other">%d 个播放列表</item>
     </plurals>
     <plurals name="n_week" tools:ignore="MissingQuantity">
-        <item quantity="other">%d weeks</item>
+        <item quantity="other">%d 周</item>
     </plurals>
     <plurals name="n_month">
-        <item quantity="other">%d months</item>
+        <item quantity="other">%d 月</item>
     </plurals>
     <plurals name="n_year">
-        <item quantity="other">%d years</item>
+        <item quantity="other">%d 年</item>
     </plurals>
-
     <!-- Snackbar -->
     <string name="playlist_imported">已导入此播放列表</string>
-    <string name="removed_song_from_playlist">Removed \"%s\" from playlist</string>
-    <string name="playlist_synced">Playlist synced</string>
-    <string name="undo">Undo</string>
-
+    <string name="removed_song_from_playlist">已从播放列表中删除“%s”</string>
+    <string name="playlist_synced">播放列表已同步</string>
+    <string name="undo">撤销</string>
     <!-- Player -->
     <string name="lyrics_not_found">没有歌词</string>
     <string name="sleep_timer">睡眠定时器</string>
@@ -169,23 +152,19 @@
     <string name="error_no_internet">没有网络连接</string>
     <string name="error_timeout">连接超时</string>
     <string name="error_unknown">未知错误</string>
-
     <!-- Player action -->
     <string name="action_like">喜欢</string>
     <string name="action_remove_like">取消喜欢</string>
-    <string name="action_shuffle_on">Shuffle on</string>
-    <string name="action_shuffle_off">Shuffle off</string>
-    <string name="repeat_mode_off">Repeat mode off</string>
-    <string name="repeat_mode_one">Repeat current song</string>
-    <string name="repeat_mode_all">Repeat queue</string>
-
+    <string name="action_shuffle_on">乱序播放开启</string>
+    <string name="action_shuffle_off">乱序播放关闭</string>
+    <string name="repeat_mode_off">循环播放关闭</string>
+    <string name="repeat_mode_one">循环播放当前歌曲</string>
+    <string name="repeat_mode_all">循环播放队列</string>
     <!-- Queue Title -->
     <string name="queue_all_songs">全部歌曲</string>
     <string name="queue_searched_songs">搜索的歌曲</string>
-
     <!-- Notification name -->
     <string name="music_player">音乐播放器</string>
-
     <!-- Settings -->
     <string name="settings">设置</string>
     <string name="appearance">外观</string>
@@ -201,7 +180,6 @@
     <string name="left">靠左</string>
     <string name="center">置中</string>
     <string name="right">靠右</string>
-
     <string name="content">内容</string>
     <string name="login">登录</string>
     <string name="content_language">默认内容语言</string>
@@ -211,7 +189,6 @@
     <string name="proxy_type">代理类型</string>
     <string name="proxy_url">代理 URL</string>
     <string name="restart_to_take_effect">重启以应用变更</string>
-
     <string name="player_and_audio">播放器与音频</string>
     <string name="audio_quality">音质</string>
     <string name="audio_quality_auto">自动</string>
@@ -221,41 +198,38 @@
     <string name="skip_silence">跳过无声片段</string>
     <string name="audio_normalization">标准化音量</string>
     <string name="equalizer">均衡器</string>
-
     <string name="storage">储存</string>
     <string name="cache">缓存</string>
     <string name="image_cache">图像缓存</string>
     <string name="song_cache">歌曲缓存</string>
     <string name="max_cache_size">最大缓存大小</string>
     <string name="unlimited">无限制</string>
-    <string name="clear_all_downloads">Clear all downloads</string>
+    <string name="clear_all_downloads">清除所有下载</string>
     <string name="max_image_cache_size">图像缓存大小</string>
     <string name="clear_image_cache">清除图像缓存</string>
     <string name="max_song_cache_size">歌曲缓存大小</string>
     <string name="clear_song_cache">清除歌曲缓存</string>
     <string name="size_used">已使用 %s</string>
-
     <string name="privacy">隐私</string>
-    <string name="pause_listen_history">暂停观看记录</string>
-    <string name="clear_listen_history">Clear listen history</string>
-    <string name="clear_listen_history_confirm">Are you sure to clear all listen history?</string>
+    <string name="pause_listen_history">暂停听歌记录</string>
+    <string name="clear_listen_history">清除听歌历史</string>
+    <string name="clear_listen_history_confirm">你确定要清除所有听歌记录吗？</string>
     <string name="pause_search_history">暂停搜索记录</string>
     <string name="clear_search_history">清除搜索记录</string>
     <string name="clear_search_history_confirm">您确定要清除所有搜索记录吗？</string>
     <string name="enable_kugou">使用酷狗音乐提供歌词</string>
-
     <string name="backup_restore">备份与还原</string>
     <string name="backup">备份</string>
     <string name="restore">还原</string>
-    <string name="imported_playlist">Imported playlist</string>
+    <string name="imported_playlist">已导入的播放列表</string>
     <string name="backup_create_success">成功新建备份</string>
     <string name="backup_create_failed">无法新建备份</string>
     <string name="restore_failed">无法还原备份</string>
-
     <string name="about">关于</string>
     <string name="app_version">应用版本</string>
-
-    <string name="new_version_available">New version available</string>
-    <string name="translation_models">Translation Models</string>
-    <string name="clear_translation_models">Clear translation models</string>
+    <string name="new_version_available">有新版本</string>
+    <string name="translation_models">翻译模型</string>
+    <string name="clear_translation_models">清除翻译模型</string>
+    <string name="delete_playlist_confirm">是否确实要删除播放列表“%s”？</string>
+    <string name="remove_download_playlist_confirm">您真的想从下载的歌曲存储中删除所有“%s”播放列表中的歌曲吗？</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -18,7 +18,6 @@
     <string name="account">帳號</string>
     <string name="quick_picks">歌曲快選</string>
     <string name="quick_picks_empty">聽一些音樂讓我們知道您的喜好</string>
-    <string name="new_release_albums">新專輯</string>
 
     <!-- History -->
     <string name="today">今天</string>

--- a/fastlane/metadata/android/pt-BR/changelogs/19.txt
+++ b/fastlane/metadata/android/pt-BR/changelogs/19.txt
@@ -1,0 +1,3 @@
+- IU melhorada
+- Layout de grade para álbuns e playlists
+- Pequenas melhoras e correção de bugs

--- a/fastlane/metadata/android/pt-BR/full_description.txt
+++ b/fastlane/metadata/android/pt-BR/full_description.txt
@@ -1,0 +1,17 @@
+Um cliente Material 3 do YouTube Music para Android
+
+<br><b>Funcionalidades:</b>
+
+- Tocar músicas do YT/YT Music sem anúncios
+- Reprodução em segundo plano
+- Pesquise músicas, vídeos, álbuns, e playlists do YouTube Music
+- Gerenciamento de biblioteca
+- Cache e download de músicas para reprodução offline
+- Letras sincronizadas
+- Pular silêncio em músicas
+- Normalização de áudio
+- Tema dinâmico
+- Tradução
+- Suporte ao Android Auto
+- Escolhas rápidas personalizadas
+- Material 3

--- a/fastlane/metadata/android/pt-BR/short_description.txt
+++ b/fastlane/metadata/android/pt-BR/short_description.txt
@@ -1,0 +1,1 @@
+Um cliente Material 3 do YouTube Music para Android

--- a/fastlane/metadata/android/pt-BR/title.txt
+++ b/fastlane/metadata/android/pt-BR/title.txt
@@ -1,0 +1,1 @@
+InnerTune

--- a/fastlane/metadata/android/zh-CN/full_description.txt
+++ b/fastlane/metadata/android/zh-CN/full_description.txt
@@ -13,5 +13,5 @@
 -动态主题
 -良好的本地化
 -支持 Android Auto
--支持 quick picks
+-支持歌曲快选 (quick picks)
 -Material 3 设计

--- a/fastlane/metadata/android/zh-CN/full_description.txt
+++ b/fastlane/metadata/android/zh-CN/full_description.txt
@@ -1,0 +1,17 @@
+一款 YouTube Music 安卓客户端，采用 Material 3 设计
+
+<br><b>功能：</b>
+
+-无广告播放 Youtube/Youtube Music 中的歌曲
+-后台播放
+-搜索歌曲、视频、专辑和播放列表
+-库管理
+-缓存和下载歌曲以供离线播放
+-同步歌词
+-跳过静默
+-音频音量规范化
+-动态主题
+-良好的本地化
+-支持 Android Auto
+-支持 quick picks
+-Material 3 设计

--- a/fastlane/metadata/android/zh-CN/short_description.txt
+++ b/fastlane/metadata/android/zh-CN/short_description.txt
@@ -1,0 +1,1 @@
+一款 YouTube Music 安卓客户端，采用 Material 3 设计

--- a/fastlane/metadata/android/zh-CN/title.txt
+++ b/fastlane/metadata/android/zh-CN/title.txt
@@ -1,0 +1,1 @@
+InnerTune


### PR DESCRIPTION
I found this https://toolate.othing.xyz/projects/innertune a while ago, and I don't think it was officially set up, but there a few changes to a few languages, so that these people's work isn't lost, this PR pulls those.

There's only really Chinese, Polish and PT-BR, Polish and PT-BR already have candidates or have been merged, so I didn't overwrite Polish. Chinese seems to be the one here that's important.