### PR TITLE
Remove translations of previously modified string

### DIFF
--- a/app/src/main/res/values-DE/strings.xml
+++ b/app/src/main/res/values-DE/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">Schnellauswahl</string>
     <string name="quick_picks_empty">Hören Sie sich einige Songs an, um Ihre Schnellauswahl zu treffen</string>
-    <string name="new_release_albums">Neu veröffentlichte Alben</string>
     <string name="forgotten_favorites">Vergessene Favoriten</string>
     <string name="similar_to">Ähnlich zu</string>
     <string name="keep_listening">Höre weiter</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -21,7 +21,6 @@
     <string name="account">Уліковы запіс</string>
     <string name="quick_picks">Хуткі выбар</string>
     <string name="quick_picks_empty">Праслухайце якія-небудзь кампазіцыі, каб стварыць ваш хуткі выбар.</string>
-    <string name="new_release_albums">Новыя рэлізы альбомаў</string>
 
     <!-- History -->
     <string name="today">Сёння</string>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">অ্যাকাউন্ট</string>
     <string name="quick_picks">দ্রুত পছন্দ</string>
     <string name="quick_picks_empty">আপনার নিজের শর্টকাট তৈরি করতে কিছু টিউন শুনুন</string>
-    <string name="new_release_albums">নতুন অ্যালবাম ও সিঙ্গেল</string>
 
     <!-- History -->
     <string name="today">আজ</string>

--- a/app/src/main/res/values-fa-rIR/strings.xml
+++ b/app/src/main/res/values-fa-rIR/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">حساب</string>
     <string name="quick_picks">انتخاب‌های سریع</string>
     <string name="quick_picks_empty">به ترانه‌ها گوش دهید تا انتخاب سریع خود ساخته شود</string>
-    <string name="new_release_albums">مجموعه‌های منتشرشده‌ی جدید</string>
 
     <!-- History -->
     <string name="today">امروز</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">Quick picks</string>
     <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">New release albums</string>
 
     <!-- History -->
     <string name="today">Today</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">Fiók</string>
     <string name="quick_picks">Gyors választás</string>
     <string name="quick_picks_empty">Hallgasson meg néhány dalt a gyors választások elkészítéséhez</string>
-    <string name="new_release_albums">Új kiadású albumok</string>
 
     <!-- History -->
     <string name="today">Ma</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -18,7 +18,6 @@
     <string name="account">Akun</string>
     <string name="quick_picks">Pilihan cepat</string>
     <string name="quick_picks_empty">Dengarkan lagu untuk menghasilkan pilihan cepat Anda</string>
-    <string name="new_release_albums">Album baru dirilis</string>
 
     <!-- History -->
     <string name="today">Hari ini</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -20,7 +20,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">Scelte rapide</string>
     <string name="quick_picks_empty">Ascolta alcuni brani per generare le tue scelte rapide</string>
-    <string name="new_release_albums">Nuovi album in uscita</string>
 
     <!-- History -->
     <string name="today">Oggi</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">アカウント</string>
     <string name="quick_picks">おすすめ</string>
     <string name="quick_picks_empty">何曲か再生するとおすすめを生成します</string>
-    <string name="new_release_albums">新作アルバム</string>
     <string name="forgotten_favorites">忘れられたお気に入り</string>
     <string name="similar_to">類似している:</string>
     <string name="keep_listening">聞き続ける</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -18,7 +18,6 @@
     <string name="account">계정</string>
     <string name="quick_picks">빠른 선곡</string>
     <string name="quick_picks_empty">빠른 선곡을 생성하려면 음악을 들으세요</string>
-    <string name="new_release_albums">새 앨범</string>
 
     <!-- History -->
     <string name="today">오늘</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">Quick picks</string>
     <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">New release albums</string>
 
     <!-- History -->
     <string name="today">Today</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">Snelle keuzes</string>
     <string name="quick_picks_empty">Beluister een aantal nummers om je snelle keuzes te genereren</string>
-    <string name="new_release_albums">Nieuwe albums</string>
 
     <!-- History -->
     <string name="today">Vandaag</string>

--- a/app/src/main/res/values-or-rIN/strings.xml
+++ b/app/src/main/res/values-or-rIN/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">Quick picks</string>
     <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">New release albums</string>
 
     <!-- History -->
     <string name="today">Today</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">ਉਂਗਲਾਂ ਤੇ ਚੁਣੇ ਗੀਤ</string>
     <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">ਨਵੀਆਂ ਜਾਰੀ ਐਲਬਮਾਂ</string>
 
     <!-- History -->
     <string name="today">ਅੱਜ</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -20,7 +20,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">Quick picks</string>
     <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">New release álbuns</string>
 
     <!-- History -->
     <string name="today">Today</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -21,7 +21,6 @@
     <string name="account">Аккаунт</string>
     <string name="quick_picks">Быстрый выбор</string>
     <string name="quick_picks_empty">Послушайте несколько песен, чтобы создать ваш быстрый выбор</string>
-    <string name="new_release_albums">Новые релизы альбомов</string>
     <string name="forgotten_favorites">Забытые любимые песни</string>
     <string name="similar_to">Похожие на</string>
     <string name="keep_listening">Продолжайте слушать</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -19,7 +19,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">Quick picks</string>
     <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">New release albums</string>
 
     <!-- History -->
     <string name="today">Today</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -21,7 +21,6 @@
     <string name="account">Акаунт</string>
     <string name="quick_picks">Швидкий вибір</string>
     <string name="quick_picks_empty">Послухайте кілька пісень, щоб створити ваш швидкий вибір</string>
-    <string name="new_release_albums">Нові релізи альбомів</string>
 
     <!-- History -->
     <string name="today">Сьогодні</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -18,7 +18,6 @@
     <string name="account">Tài Khoản</string>
     <string name="quick_picks">Chọn nhanh</string>
     <string name="quick_picks_empty">Nghe các bài hát để tạo danh sách chọn nhanh của bạn</string>
-    <string name="new_release_albums">Các albums mới phát hành</string>
 
     <!-- History -->
     <string name="today">Hôm nay</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -18,7 +18,6 @@
     <string name="account">Account</string>
     <string name="quick_picks">歌曲快选</string>
     <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
-    <string name="new_release_albums">新专辑</string>
 
     <!-- History -->
     <string name="today">今天</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -18,7 +18,6 @@
     <string name="account">帳號</string>
     <string name="quick_picks">歌曲快選</string>
     <string name="quick_picks_empty">聽一些音樂讓我們知道您的喜好</string>
-    <string name="new_release_albums">新專輯</string>
 
     <!-- History -->
     <string name="today">今天</string>


### PR DESCRIPTION
The 'New releases album' string was modified without removing the translations which still mentioned them.

* A few here weren't removed because they've been updated recently or have obviously never mentioned albums

This should be done for the purpose of maintaining strings properly so that this project can properly integrate with translation solutions like Weblate for instance