### PR TITLE
Fix "Unknown Error" on Playback Request Due to InnerTube API Changes

### DIFF
--- a/app/src/main/java/com/malopieds/innertune/playback/DownloadUtil.kt
+++ b/app/src/main/java/com/malopieds/innertune/playback/DownloadUtil.kt
@@ -99,9 +99,13 @@ class DownloadUtil
                     )
                 }
 
+                val streamURL = playbackData.streamUrl.let {
+                    // Avoid being throttled
+                    "${it}&range=0-${format.contentLength ?: 10000000}"
+                }
                 val expirationTime = System.currentTimeMillis() + (playbackData.streamExpiresInSeconds * 1000L)
-                songUrlCache[mediaId] = playbackData.streamUrl to expirationTime
-                dataSpec.withUri(format.url!!.toUri())
+                songUrlCache[mediaId] = streamURL to expirationTime
+                dataSpec.withUri(streamURL.toUri())
             }
         val downloadNotificationHelper = DownloadNotificationHelper(context, ExoDownloadService.CHANNEL_ID)
         val downloadManager: DownloadManager =

--- a/app/src/main/java/com/malopieds/innertune/playback/DownloadUtil.kt
+++ b/app/src/main/java/com/malopieds/innertune/playback/DownloadUtil.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.ConnectivityManager
 import androidx.core.content.getSystemService
 import androidx.core.net.toUri
-import androidx.media3.common.PlaybackException
 import androidx.media3.database.DatabaseProvider
 import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.datasource.cache.CacheDataSource
@@ -13,6 +12,7 @@ import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadManager
 import androidx.media3.exoplayer.offline.DownloadNotificationHelper
+import com.malopieds.innertune.utils.YTPlayerUtils
 import com.malopieds.innertube.YouTube
 import com.malopieds.innertune.constants.AudioQuality
 import com.malopieds.innertune.constants.AudioQualityKey
@@ -73,34 +73,16 @@ class DownloadUtil
                 }
 
                 val playedFormat = runBlocking(Dispatchers.IO) { database.format(mediaId).first() }
-                val playerResponse =
+                val playbackData =
                     runBlocking(Dispatchers.IO) {
-                        YouTube.player(mediaId)
+                        YTPlayerUtils.playerResponseForPlayback(
+                            mediaId,
+                            playedFormat = playedFormat,
+                            audioQuality = audioQuality,
+                            connectivityManager = connectivityManager,
+                        )
                     }.getOrThrow()
-                if (playerResponse.playabilityStatus.status != "OK") {
-                    throw PlaybackException(playerResponse.playabilityStatus.reason, null, PlaybackException.ERROR_CODE_REMOTE_ERROR)
-                }
-
-                val format =
-                    if (playedFormat != null) {
-                        playerResponse.streamingData?.adaptiveFormats?.find { it.itag == playedFormat.itag }
-                    } else {
-                        playerResponse.streamingData
-                            ?.adaptiveFormats
-                            ?.filter { it.isAudio }
-                            ?.maxByOrNull {
-                                it.bitrate *
-                                    when (audioQuality) {
-                                        AudioQuality.AUTO -> if (connectivityManager.isActiveNetworkMetered) -1 else 1
-                                        AudioQuality.HIGH -> 1
-                                        AudioQuality.LOW -> -1
-                                    } + (if (it.mimeType.startsWith("audio/webm")) 10240 else 0) // prefer opus stream
-                            }
-                    }!!.let {
-                        // Specify range to avoid YouTube's throttling
-                        val url = if (it.url != null) it.url else it.findUrl()
-                        it.copy(url = "${url}&range=0-${it.contentLength ?: 10000000}")
-                    }
+                val format = playbackData.format
 
                 database.query {
                     upsert(
@@ -112,12 +94,13 @@ class DownloadUtil
                             bitrate = format.bitrate,
                             sampleRate = format.audioSampleRate,
                             contentLength = format.contentLength!!,
-                            loudnessDb = playerResponse.playerConfig?.audioConfig?.loudnessDb,
+                            loudnessDb = playbackData.audioConfig?.loudnessDb
                         ),
                     )
                 }
 
-                songUrlCache[mediaId] = format.url!! to playerResponse.streamingData!!.expiresInSeconds * 1000L
+                val expirationTime = System.currentTimeMillis() + (playbackData.streamExpiresInSeconds * 1000L)
+                songUrlCache[mediaId] = playbackData.streamUrl to expirationTime
                 dataSpec.withUri(format.url!!.toUri())
             }
         val downloadNotificationHelper = DownloadNotificationHelper(context, ExoDownloadService.CHANNEL_ID)

--- a/app/src/main/java/com/malopieds/innertune/utils/YTPlayerUtils.kt
+++ b/app/src/main/java/com/malopieds/innertune/utils/YTPlayerUtils.kt
@@ -1,0 +1,206 @@
+package com.malopieds.innertune.utils
+
+import android.net.ConnectivityManager
+import androidx.media3.common.PlaybackException
+import com.malopieds.innertube.YouTube
+import com.malopieds.innertube.models.YouTubeClient
+import com.malopieds.innertube.models.YouTubeClient.Companion.IOS
+import com.malopieds.innertube.models.YouTubeClient.Companion.MAIN_CLIENT
+import com.malopieds.innertube.models.YouTubeClient.Companion.TVHTML5
+import com.malopieds.innertube.models.response.PlayerResponse
+import com.malopieds.innertube.utils.NewPipeUtils
+import com.malopieds.innertune.constants.AudioQuality
+import com.malopieds.innertune.db.entities.FormatEntity
+import okhttp3.OkHttpClient
+
+object YTPlayerUtils {
+
+    private val httpClient = OkHttpClient.Builder()
+        .proxy(YouTube.proxy)
+        .build()
+
+    /**
+     * The main client is used for metadata and initial streams.
+     * Do not use other clients for this because it can result in inconsistent metadata.
+     * For example other clients can have different normalization targets (loudnessDb).
+     *
+     * [com.malopieds.innertube.models.YouTubeClient.WEB_REMIX] should be preferred here because currently
+     * it is the only client which provides:
+     * - the correct metadata (like loudnessDb)
+     * - premium formats
+     */
+    private val MAIN_CLIENT: YouTubeClient = YouTubeClient.MAIN_CLIENT
+
+    /**
+     * Clients used for fallback streams in case the streams of the main client do not work.
+     */
+    private val STREAM_FALLBACK_CLIENTS: List<YouTubeClient> = listOf(
+        TVHTML5,
+        IOS,
+    )
+
+    data class PlaybackData(
+        val audioConfig: PlayerResponse.PlayerConfig.AudioConfig?,
+        val videoDetails: PlayerResponse.VideoDetails?,
+        val format: PlayerResponse.StreamingData.Format,
+        val streamUrl: String,
+        val streamExpiresInSeconds: Int,
+    )
+
+    /**
+     * Custom player response intended to use for playback.
+     * Metadata like audioConfig and videoDetails are from [MAIN_CLIENT].
+     * Format & stream can be from [MAIN_CLIENT] or [STREAM_FALLBACK_CLIENTS].
+     */
+    suspend fun playerResponseForPlayback(
+        videoId: String,
+        playlistId: String? = null,
+        playedFormat: FormatEntity?,
+        audioQuality: AudioQuality,
+        connectivityManager: ConnectivityManager,
+    ): Result<PlaybackData> = runCatching {
+        /**
+         * This is required for some clients to get working streams however
+         * it should not be forced for the [MAIN_CLIENT] because the response of the [MAIN_CLIENT]
+         * is required even if the streams won't work from this client.
+         * This is why it is allowed to be null.
+         */
+        val signatureTimestamp = getSignatureTimestampOrNull(videoId)
+        val mainPlayerResponse =
+            YouTube.player(videoId, playlistId, MAIN_CLIENT, signatureTimestamp).getOrThrow()
+
+        val audioConfig = mainPlayerResponse.playerConfig?.audioConfig
+        val videoDetails = mainPlayerResponse.videoDetails
+
+        var format: PlayerResponse.StreamingData.Format? = null
+        var streamUrl: String? = null
+        var streamExpiresInSeconds: Int? = null
+        var streamPlayerResponse: PlayerResponse? = null
+
+        for (clientIndex in (-1 until STREAM_FALLBACK_CLIENTS.size)) {
+            streamPlayerResponse =
+                when (clientIndex) {
+                    -1 -> mainPlayerResponse
+                    else -> {
+                        if (clientIndex !in STREAM_FALLBACK_CLIENTS.indices) continue // skip if index is out of range
+                        val client = STREAM_FALLBACK_CLIENTS[clientIndex]
+                        if (client.loginRequired && YouTube.cookie == null) {
+                            // skip client if it requires login but user is not logged in
+                            continue
+                        }
+                        YouTube.player(videoId, playlistId, client, signatureTimestamp).getOrNull()
+                    }
+                }
+
+            if (streamPlayerResponse?.statusOk() != true) continue // skip client
+            format = findFormat(
+                streamPlayerResponse,
+                playedFormat,
+                audioQuality,
+                connectivityManager,
+            ) ?: continue
+            streamUrl = findUrlOrNull(format, videoId) ?: continue
+            streamExpiresInSeconds = streamPlayerResponse.streamingData?.expiresInSeconds ?: continue
+
+            when (clientIndex) {
+                STREAM_FALLBACK_CLIENTS.size - 1 -> continue /** skip [validateStatus] for last client */
+                else -> {
+                    if (validateStatus(streamUrl)) break  // Found a working stream
+                }
+            }
+        }
+
+        if (streamPlayerResponse == null) throw Exception("Bad stream player response")
+        if (!streamPlayerResponse.statusOk()) {
+            throw PlaybackException(
+                streamPlayerResponse.playabilityStatus.reason,
+                null,
+                PlaybackException.ERROR_CODE_REMOTE_ERROR
+            )
+        }
+        if (streamExpiresInSeconds == null) throw Exception("Missing stream expire time")
+        if (format == null) throw Exception("Could not find format")
+        if (streamUrl == null) throw Exception("Could not find stream url")
+
+        PlaybackData(
+            audioConfig,
+            videoDetails,
+            format,
+            streamUrl,
+            streamExpiresInSeconds,
+        )
+    }
+
+    /**
+     * Simple player response intended to use for metadata only.
+     * Stream URLs of this response might not work so don't use them.
+     */
+    suspend fun playerResponseForMetadata(
+        videoId: String,
+        playlistId: String? = null,
+    ): Result<PlayerResponse> =
+        YouTube.player(videoId, playlistId, client = MAIN_CLIENT)
+
+    private fun findFormat(
+        playerResponse: PlayerResponse,
+        playedFormat: FormatEntity?,
+        audioQuality: AudioQuality,
+        connectivityManager: ConnectivityManager,
+    ): PlayerResponse.StreamingData.Format? =
+        if (playedFormat != null) {
+            playerResponse.streamingData?.adaptiveFormats?.find { it.itag == playedFormat.itag }
+        } else {
+            playerResponse.streamingData?.adaptiveFormats
+                ?.filter { it.isAudio }
+                ?.maxByOrNull {
+                    it.bitrate * when (audioQuality) {
+                        AudioQuality.AUTO -> if (connectivityManager.isActiveNetworkMetered) -1 else 1
+                        AudioQuality.HIGH -> 1
+                        AudioQuality.LOW -> -1
+                    } + (if (it.mimeType.startsWith("audio/webm")) 10240 else 0) // prefer opus stream
+                }
+        }
+
+    /**
+     * Checks if the stream url returns a successful status.
+     * If this returns true the url is likely to work.
+     * If this returns false the url might cause an error during playback.
+     */
+    private fun validateStatus(url: String): Boolean {
+        try {
+            val requestBuilder = okhttp3.Request.Builder()
+                .head()
+                .url(url)
+            val response = httpClient.newCall(requestBuilder.build()).execute()
+            return response.isSuccessful
+        } catch (e: Exception) {
+            reportException(e)
+        }
+        return false
+    }
+
+    /**
+     * Wrapper around the [NewPipeUtils.getSignatureTimestamp] function which reports exceptions
+     */
+    private fun getSignatureTimestampOrNull(
+        videoId: String
+    ): Int? {
+        return NewPipeUtils.getSignatureTimestamp(videoId)
+            .onFailure {
+                reportException(it)
+            }.getOrNull()
+    }
+
+    /**
+     * Wrapper around the [NewPipeUtils.getStreamUrl] function which reports exceptions
+     */
+    private fun findUrlOrNull(
+        format: PlayerResponse.StreamingData.Format,
+        videoId: String
+    ): String? {
+        return NewPipeUtils.getStreamUrl(format, videoId)
+            .onFailure {
+                reportException(it)
+            }.getOrNull()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ hilt = "2.51.1"
 ktor = "2.3.12"
 ksp = "2.0.0-1.0.24"
 squigglyslider = "1.0.0"
+newpipeExtractor = "0.24.4"
 
 [libraries]
 annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
@@ -80,6 +81,8 @@ desugaring = { group = "com.android.tools", name = "desugar_jdk_libs", version =
 junit = { group = "junit", name = "junit", version = "4.13.2" }
 
 timber = { group = "com.jakewharton.timber", name = "timber", version = "5.0.1" }
+
+newpipeExtractor = { module = "com.github.TeamNewPipe:NewPipeExtractor", version.ref = "newpipeExtractor" }
 
 [plugins]
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/innertube/build.gradle.kts
+++ b/innertube/build.gradle.kts
@@ -15,5 +15,6 @@ dependencies {
     implementation(libs.ktor.serialization.json)
     implementation(libs.ktor.client.encoding)
     implementation(libs.brotli)
+    implementation(libs.newpipeExtractor)
     testImplementation(libs.junit)
 }

--- a/innertube/src/main/java/com/malopieds/innertube/InnerTube.kt
+++ b/innertube/src/main/java/com/malopieds/innertube/InnerTube.kt
@@ -12,10 +12,8 @@ import com.malopieds.innertube.models.body.GetTranscriptBody
 import com.malopieds.innertube.models.body.NextBody
 import com.malopieds.innertube.models.body.PlayerBody
 import com.malopieds.innertube.models.body.SearchBody
-import com.malopieds.innertube.utils.nSigDecode
 import com.malopieds.innertube.utils.parseCookieString
 import com.malopieds.innertube.utils.sha1
-import com.malopieds.innertube.utils.sigDecode
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.compression.ContentEncoding
@@ -28,9 +26,7 @@ import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
-import io.ktor.http.URLBuilder
 import io.ktor.http.contentType
-import io.ktor.http.parseQueryString
 import io.ktor.http.userAgent
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.util.encodeBase64
@@ -95,7 +91,7 @@ class InnerTube {
             }
 
             defaultRequest {
-                url("https://music.youtube.com/youtubei/v1/")
+                url(YouTubeClient.API_URL_YOUTUBE_MUSIC)
             }
         }
 
@@ -106,18 +102,16 @@ class InnerTube {
         contentType(ContentType.Application.Json)
         headers {
             append("X-Goog-Api-Format-Version", "1")
-            append("X-YouTube-Client-Name", client.clientName)
+            append("X-YouTube-Client-Name", client.clientId)
             append("X-YouTube-Client-Version", client.clientVersion)
-            append("x-origin", "https://music.youtube.com")
-            if (client.referer != null) {
-                append("Referer", client.referer)
-            }
-            if (setLogin) {
+            append("X-Origin", YouTubeClient.ORIGIN_YOUTUBE_MUSIC)
+            append("Referer", YouTubeClient.REFERER_YOUTUBE_MUSIC)
+            if (setLogin && client.loginSupported) {
                 cookie?.let { cookie ->
                     append("cookie", cookie)
                     if ("SAPISID" !in cookieMap) return@let
                     val currentTime = System.currentTimeMillis() / 1000
-                    val sapisidHash = sha1("$currentTime ${cookieMap["SAPISID"]} https://music.youtube.com")
+                    val sapisidHash = sha1("$currentTime ${cookieMap["SAPISID"]} ${YouTubeClient.ORIGIN_YOUTUBE_MUSIC}")
                     append("Authorization", "SAPISIDHASH ${currentTime}_$sapisidHash")
                 }
             }
@@ -149,6 +143,7 @@ class InnerTube {
         client: YouTubeClient,
         videoId: String,
         playlistId: String?,
+        signatureTimestamp: Int?
     ) = httpClient.post("player") {
         ytClient(client, setLogin = true)
         setBody(
@@ -168,6 +163,12 @@ class InnerTube {
                     },
                 videoId = videoId,
                 playlistId = playlistId,
+                playbackContext =
+                    if (client.useSignatureTimestamp && signatureTimestamp != null) {
+                        PlayerBody.PlaybackContext(contentPlaybackContext = PlayerBody.ContentPlaybackContext(
+                            signatureTimestamp = signatureTimestamp
+                        ))
+                    } else null
             ),
         )
     }

--- a/innertube/src/main/java/com/malopieds/innertube/InnerTube.kt
+++ b/innertube/src/main/java/com/malopieds/innertube/InnerTube.kt
@@ -117,7 +117,6 @@ class InnerTube {
             }
         }
         userAgent(client.userAgent)
-        parameter("key", client.api_key)
         parameter("prettyPrint", false)
     }
 

--- a/innertube/src/main/java/com/malopieds/innertube/models/YouTubeClient.kt
+++ b/innertube/src/main/java/com/malopieds/innertube/models/YouTubeClient.kt
@@ -6,10 +6,14 @@ import kotlinx.serialization.Serializable
 data class YouTubeClient(
     val clientName: String,
     val clientVersion: String,
+    val clientId: String,
     val osVersion: String? = null,
     val api_key: String,
     val userAgent: String,
-    val referer: String? = null,
+    val loginRequired: Boolean = false,
+    val loginSupported: Boolean = false,
+    val useSignatureTimestamp: Boolean = false,
+    val isEmbedded: Boolean = false,
 ) {
     fun toContext(
         locale: YouTubeLocale,
@@ -27,16 +31,23 @@ data class YouTubeClient(
     )
 
     companion object {
-        private const val REFERER_YOUTUBE_MUSIC = "https://music.youtube.com/"
+        const val ORIGIN_YOUTUBE_MUSIC = "https://music.youtube.com"
+        const val REFERER_YOUTUBE_MUSIC = "$ORIGIN_YOUTUBE_MUSIC/"
+        const val API_URL_YOUTUBE_MUSIC = "$ORIGIN_YOUTUBE_MUSIC/youtubei/v1/"
 
-        private const val USER_AGENT_WEB = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36"
-        private const val USER_AGENT_ANDROID = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Mobile Safari/537.36"
-        const val USER_AGENT_IOS = "com.google.ios.youtube/19.29.1 (iPhone16,2; U; CPU iOS 17_5_1 like Mac OS X;)"
+        const val USER_AGENT_WEB =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36"
+        private const val USER_AGENT_ANDROID =
+            "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Mobile Safari/537.36"
+        private const val USER_AGENT_IOS = "com.google.ios.youtube/19.29.1 (iPhone16,2; U; CPU iOS 17_5_1 like Mac OS X;)"
+        private const val USER_AGENT_TVHTML5 =
+            "Mozilla/5.0 (PlayStation; PlayStation 4/12.00) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Safari/605.1.15"
 
         val ANDROID_MUSIC =
             YouTubeClient(
                 clientName = "ANDROID_MUSIC",
                 clientVersion = "5.54.52",
+                clientId = "21",
                 api_key = "AIzaSyAOghZGza2MQSZkY_zfZ370N-PUdXEo8AI",
                 userAgent = USER_AGENT_ANDROID,
             )
@@ -45,21 +56,24 @@ data class YouTubeClient(
             YouTubeClient(
                 clientName = "ANDROID",
                 clientVersion = "17.13.3",
+                clientId = "3",
                 api_key = "AIzaSyA8eiZmM1FaDVjRy-df2KTyQ_vz_yYM39w",
                 userAgent = USER_AGENT_ANDROID,
             )
         val IOS =
             YouTubeClient(
                 clientName = "IOS",
-                clientVersion = "19.29.1",
-                osVersion = "17.5.1.21F90",
+                clientVersion = "19.45.4",
+                clientId = "5",
+                osVersion = "18.1.0.22B83",
                 api_key = "AIzaSyB-63vPrdThhKuerbB2N_l7Kwwcxj6yUAc",
                 userAgent = USER_AGENT_IOS,
             )
         val WEB =
             YouTubeClient(
                 clientName = "WEB",
-                clientVersion = "2.2021111",
+                clientVersion = "2.20241126.01.00",
+                clientId = "1",
                 api_key = "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX3",
                 userAgent = USER_AGENT_WEB,
             )
@@ -67,18 +81,26 @@ data class YouTubeClient(
         val WEB_REMIX =
             YouTubeClient(
                 clientName = "WEB_REMIX",
-                clientVersion = "1.20241023.01.00",
+                clientVersion = "1.20241127.01.00",
+                clientId = "67",
                 api_key = "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30",
                 userAgent = USER_AGENT_WEB,
-                referer = REFERER_YOUTUBE_MUSIC,
+                loginSupported = true,
+                useSignatureTimestamp = true,
             )
 
         val TVHTML5 =
             YouTubeClient(
                 clientName = "TVHTML5_SIMPLY_EMBEDDED_PLAYER",
                 clientVersion = "2.0",
+                clientId = "85",
                 api_key = "AIzaSyDCU8hByM-4DrUqRUYnGn-3llEO78bcxq8",
-                userAgent = "Mozilla/5.0 (PlayStation 4 5.55) AppleWebKit/601.2 (KHTML, like Gecko)",
+                userAgent = USER_AGENT_TVHTML5,
+                loginSupported = true,
+                loginRequired = true,
+                useSignatureTimestamp = true,
+                isEmbedded = true,
             )
+        val MAIN_CLIENT = WEB_REMIX
     }
 }

--- a/innertube/src/main/java/com/malopieds/innertube/models/body/PlayerBody.kt
+++ b/innertube/src/main/java/com/malopieds/innertube/models/body/PlayerBody.kt
@@ -9,7 +9,7 @@ data class PlayerBody(
     val videoId: String,
     val playlistId: String?,
     val cpn: String? = "wzf9Y0nqz6AUe2Vr", // need some random cpn to get same algorithm for sig
-    val playbackContext: PlaybackContext? = PlaybackContext(ContentPlaybackContext(20052L)),
+    val playbackContext: PlaybackContext? = PlaybackContext(ContentPlaybackContext(20052)),
 ) {
     @Serializable
     data class PlaybackContext(
@@ -18,6 +18,6 @@ data class PlayerBody(
 
     @Serializable
     data class ContentPlaybackContext(
-        val signatureTimestamp: Long?,
+        val signatureTimestamp: Int?,
     )
 }

--- a/innertube/src/main/java/com/malopieds/innertube/models/response/PlayerResponse.kt
+++ b/innertube/src/main/java/com/malopieds/innertube/models/response/PlayerResponse.kt
@@ -2,7 +2,6 @@ package com.malopieds.innertube.models.response
 
 import com.malopieds.innertube.models.ResponseContext
 import com.malopieds.innertube.models.Thumbnails
-import com.malopieds.innertube.utils.createUrl
 import kotlinx.serialization.Serializable
 
 /**
@@ -62,8 +61,6 @@ data class PlayerResponse(
         ) {
             val isAudio: Boolean
                 get() = width == null
-
-            fun findUrl() = url?.let { createUrl(url = it) } ?: signatureCipher?.let { createUrl(cipher = it) }!!
         }
     }
 
@@ -78,4 +75,8 @@ data class PlayerResponse(
         val viewCount: String,
         val thumbnail: Thumbnails,
     )
+
+    fun statusOk(): Boolean {
+        return playabilityStatus.status == "OK"
+    }
 }

--- a/innertube/src/main/java/com/malopieds/innertube/utils/NewPipeUtils.kt
+++ b/innertube/src/main/java/com/malopieds/innertube/utils/NewPipeUtils.kt
@@ -1,0 +1,82 @@
+package com.malopieds.innertube.utils
+
+import com.malopieds.innertube.YouTube
+import com.malopieds.innertube.models.YouTubeClient
+import com.malopieds.innertube.models.response.PlayerResponse
+import io.ktor.http.URLBuilder
+import io.ktor.http.parseQueryString
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.schabi.newpipe.extractor.NewPipe
+import org.schabi.newpipe.extractor.downloader.Downloader
+import org.schabi.newpipe.extractor.downloader.Request
+import org.schabi.newpipe.extractor.downloader.Response
+import org.schabi.newpipe.extractor.exceptions.ParsingException
+import org.schabi.newpipe.extractor.exceptions.ReCaptchaException
+import org.schabi.newpipe.extractor.services.youtube.YoutubeJavaScriptPlayerManager
+import java.io.IOException
+import java.net.Proxy
+
+object NewPipeUtils {
+    init {
+        NewPipe.init(NewPipeDownloaderImpl(YouTube.proxy))
+    }
+
+    fun getSignatureTimestamp(videoId: String): Result<Int> = runCatching {
+        YoutubeJavaScriptPlayerManager.getSignatureTimestamp(videoId)
+    }
+
+    fun getStreamUrl(format: PlayerResponse.StreamingData.Format, videoId: String) = runCatching {
+        format.url?.let {
+            return@runCatching it
+        }
+        format.signatureCipher?.let { signatureCipher ->
+            val params = parseQueryString(signatureCipher)
+            val obfuscatedSignature = params["s"] ?: throw ParsingException("Could not parse cipher signature")
+            val signatureParam = params["sp"] ?: throw ParsingException("Could not parse cipher signature parameter")
+            val url = params["url"]?.let { URLBuilder(it) } ?: throw ParsingException("Could not parse cipher url")
+            url.parameters[signatureParam] = YoutubeJavaScriptPlayerManager.deobfuscateSignature(videoId, obfuscatedSignature)
+            return@runCatching YoutubeJavaScriptPlayerManager.getUrlWithThrottlingParameterDeobfuscated(videoId, url.toString())
+        }
+        throw ParsingException("Could not find format url")
+    }
+}
+
+private class NewPipeDownloaderImpl(proxy: Proxy?) : Downloader() {
+    private val client = OkHttpClient.Builder()
+        .proxy(proxy)
+        .build()
+
+    @Throws(IOException::class, ReCaptchaException::class)
+    override fun execute(request: Request): Response {
+        val httpMethod = request.httpMethod()
+        val url = request.url()
+        val headers = request.headers()
+        val dataToSend = request.dataToSend()
+        val requestBuilder = okhttp3.Request.Builder()
+            .method(httpMethod, dataToSend?.toRequestBody())
+            .url(url)
+            .addHeader("User-Agent", YouTubeClient.USER_AGENT_WEB)
+
+        headers.forEach { (headerName, headerValueList) ->
+            if (headerValueList.size > 1) {
+                requestBuilder.removeHeader(headerName)
+                headerValueList.forEach { headerValue ->
+                    requestBuilder.addHeader(headerName, headerValue)
+                }
+            } else if (headerValueList.size == 1) {
+                requestBuilder.header(headerName, headerValueList[0])
+            }
+        }
+
+        val response = client.newCall(requestBuilder.build()).execute()
+        if (response.code == 429) {
+            response.close()
+            throw ReCaptchaException("reCaptcha Challenge requested", url)
+        }
+
+        val responseBodyToReturn = response.body?.string()
+        val latestUrl = response.request.url.toString()
+        return Response(response.code, response.message, response.headers.toMultimap(), responseBodyToReturn, latestUrl)
+    }
+}

--- a/kugou/src/test/java/Test.kt
+++ b/kugou/src/test/java/Test.kt
@@ -1,5 +1,4 @@
 import com.malopieds.kugou.KuGou
-import com.malopieds.kugou.KuGou.generateKeyword
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -7,8 +6,16 @@ import org.junit.Test
 class Test {
     @Test
     fun test() = runBlocking {
-        val candidates = KuGou.getLyricsCandidate(generateKeyword("千年以後 (After A Thousand Years)", "陳零九"), 285)
-        assertTrue(candidates != null)
-        assertTrue(KuGou.getLyrics("楊丞琳", "點水", 259).isSuccess)
+        val lyrics = KuGou.getLyrics(title = "千年以後 (After A Thousand Years)", artist = "陳零九", duration = 285).getOrNull()
+        when {
+            lyrics == null -> assertTrue(false)
+            else -> {
+                assert(lyrics.isNotEmpty())
+                println(lyrics)
+                assertTrue(lyrics.contains("[00:00.00]千年以后 - 陈零九 (Nine Chen)"))
+                assertTrue(lyrics.contains("[03:10.04]徘徊不定的爱 数不尽的猜"))
+                assertTrue(lyrics.contains("[04:23.07]在千年以后"))
+            }
+        }
     }
 }


### PR DESCRIPTION
### Should: fix #433, fix #438, fix #445, fix #463, fix #467

### Summary:
Due to recent InnerTube changes, playback data and valid streams cannot be returned to the client, resulting in 403 responses or invalid playability status in the `PlayerResponse`. A similar solution is used in [OuterTune](https://github.com/DD3Boh/OuterTune/tree/dev) and [Metrolist](https://github.com/mostafaalagamy/Metrolist) to handle these issues. Credits: @gechoto.

**Note**: Direct streams seem to cause issues once in a while, such as playback interrupts or timeouts. This might be due to the current version of NewPipeExtractor (0.24.4) failing to deobfuscate Throttling Params. Commit [1ca8275](https://github.com/TeamNewPipe/NewPipeExtractor/commit/1ca8275419ff0ae9cf1dc44c651ae0e968c2954c) resolves this, so maybe that could be used in the meantime until the next version release?